### PR TITLE
Add method to build database from file

### DIFF
--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -1,6 +1,7 @@
 use simstring_rust::database::HashDB;
 use simstring_rust::extractors::CharacterNGrams;
 use simstring_rust::measures::Cosine;
+use std::env;
 
 fn main() {
     let feature_extractor = CharacterNGrams {
@@ -10,10 +11,9 @@ fn main() {
     let measure = Cosine::new();
     let mut db = HashDB::new(feature_extractor, measure);
 
-    db.insert("hello".to_string());
-    db.insert("help".to_string());
-    db.insert("halo".to_string());
-    db.insert("world".to_string());
+    let current_dir = env::current_dir().unwrap();
+    let file_path = current_dir.join("examples").join("data").join("example_data.txt");
+    db.build_from_file(file_path.to_str().unwrap()).unwrap();
 
     let threshold = 0.5;
     let results = db.search("hell", threshold);

--- a/src/database/hashdb.rs
+++ b/src/database/hashdb.rs
@@ -1,6 +1,8 @@
 use crate::search::SearchResult;
 use crate::{FeatureExtractor, SimStringDB, SimilarityMeasure};
 use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::io::{BufRead, BufReader};
 
 pub struct HashDB<TExtractor, TMeasure>
 where
@@ -49,6 +51,18 @@ where
                 .or_default()
                 .insert(s.clone());
         }
+    }
+
+    pub fn build_from_file(&mut self, file_path: &str) -> std::io::Result<()> {
+        let file = File::open(file_path)?;
+        let reader = BufReader::new(file);
+
+        for line in reader.lines() {
+            let line = line?;
+            self.insert(line);
+        }
+
+        Ok(())
     }
 
     pub fn search(&mut self, query: &str, alpha: f64) -> Vec<SearchResult<String>> {

--- a/tests/test_database.rs
+++ b/tests/test_database.rs
@@ -307,4 +307,26 @@ mod hashdb_tests {
             .sum();
         assert_eq!(total_ngrams, total_ngrams_expected);
     }
+
+    #[test]
+    fn test_build_from_file() {
+        let feature_extractor = CharacterNGrams {
+            n: 2,
+            padder: " ".to_string(),
+        };
+        let measure = Cosine {};
+        let mut db = HashDB::new(feature_extractor, measure);
+
+        let file_path = "tests/data/test_data.txt";
+        db.build_from_file(file_path).unwrap();
+
+        let expected_strings: HashSet<String> = ["hello".to_string(), "world".to_string()]
+            .iter()
+            .cloned()
+            .collect();
+
+        let actual_strings: HashSet<String> = db.string_collection.iter().cloned().collect();
+
+        assert_eq!(actual_strings, expected_strings);
+    }
 }


### PR DESCRIPTION
Fixes #9

Add method to build database from file sources.

* Add `build_from_file` method to `HashDB` in `src/database/hashdb.rs` to read data from a file and build the database.
* Update `examples/basic_usage.rs` to demonstrate the usage of the new `build_from_file` method.
* Add test in `tests/test_database.rs` to verify the functionality of the `build_from_file` method.

