### PR TITLE
fix(ci): maturin can't publish generated bindings as it can't find th…

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -284,6 +284,7 @@ jobs:
     permissions:
       id-token: write
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           pattern: wheels-*
@@ -293,8 +294,8 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: upload
-          args: --non-interactive --skip-existing
-          repository-url: https://test.pypi.org
+          args: --non-interactive --skip-existing --repository-url https://test.pypi.org/legacy/
+          working-directory: .
 
   publish_to_pypi:
     name: Publish to PyPI
@@ -307,6 +308,7 @@ jobs:
     permissions:
       id-token: write
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           pattern: wheels-*
@@ -316,7 +318,8 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: upload
-          args: --non-interactive --skip-existing
+          args: --non-interactive --skip-existing --repository-url https://upload.pypi.org/legacy/
+          working-directory: .
 
   run-examples:
     name: Run Examples


### PR DESCRIPTION
---
name: Pull Request
about: Fix maturin build of python binding wheels
title: 'fix(ci): maturin can't publish generated bindings'
labels: ''
assignees: ''

---

**Description**

maturin can't publish generated bindings as it can't find the correct path. This PR tries to fix that

**Fixes** (#22 )

**Type of change**

- [X] `fix(ci)`: maturin can't publish generated bindings


**How Has This Been Tested?**

NN

**Checklist:**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
